### PR TITLE
Take an `expr` not a `fn`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: cross
-Title: Run Functions Across Package Versions
+Title: Run Expressions Across Package Versions
 Version: 0.0.0.9000
 Authors@R: c(
     person("Davis", "Vaughan", , "davis@posit.co", role = c("aut", "cre")),
     person("Posit Software, PBC", role = c("cph", "fnd"))
   )
-Description: Tooling to run a single function across multiple package
+Description: Tooling to run a single expression across multiple package
     versions or across multiple local branches, which is particularly
     useful for running before and after benchmarks.
 License: MIT + file LICENSE

--- a/README.Rmd
+++ b/README.Rmd
@@ -27,7 +27,7 @@ knitr::opts_chunk$set(
 
 <!-- badges: end -->
 
-The goal of cross is to rerun a single function across a configuration of package versions or git branches.
+The goal of cross is to run a single expression across a configuration of package versions or git branches.
 The typical use case for this is creating a reprex containing a before and after benchmark, where you'd like to run the same code on both the `main` branch and your `branch/my-fix` branch, or using the CRAN version of a package against the dev version of a package.
 
 ## Installation
@@ -40,12 +40,12 @@ pak::pak("DavisVaughan/cross")
 
 ## Example
 
-`cross::bench_versions()` runs a function across various versions of the same package.
-The function itself must end with a call to either `bench::mark()` or `bench::press()`.
+`cross::bench_versions()` runs an expression across various versions of the same package.
+The expression itself must end with a call to either `bench::mark()` or `bench::press()`.
 The `pkgs` can be any remote specification supported by `pak::pkg_install()`.
 
 ```{r, eval=FALSE}
-out <- cross::bench_versions(pkgs = c("vctrs", "r-lib/vctrs"), \() {
+out <- cross::bench_versions(pkgs = c("vctrs", "r-lib/vctrs"), {
   library(vctrs)
   x <- c(1, NA, 2, 3, NA)
   bench::mark(missing = vec_detect_missing(x))
@@ -61,24 +61,24 @@ out
 #> #   time <list>, gc <list>
 ```
 
-`cross::bench_branches()` runs a function across various local branches.
+`cross::bench_branches()` runs an expression across various local branches.
 It assumes that:
 
 -   `usethis::proj_get()` points to an R package using git.
 -   There are no uncommitted git changes.
 
-If those are true, then it will automatically run the function against the current branch and the `main` branch, but you can change this with the `current` and `branches` arguments.
+If those are true, then it will automatically run the expression against the current branch and the `main` branch, but you can change this with the `current` and `branches` arguments.
 
 ```{r, eval=FALSE}
 # Not run here, but assuming we are in the vctrs repo this would run the
-# function against whatever branch we are on and the `main` branch
+# expression against whatever branch we are on and the `main` branch
 
-cross::bench_branches(\() {
+cross::bench_branches({
   library(vctrs)
   x <- c(1, NA, 2, 3, NA)
   bench::mark(missing = vec_detect_missing(x))
 })
 ```
 
-The underlying engines that powers these are `cross::run_versions()` and `cross::run_branches()`, which allow you to run any arbitrary function across multiple package versions or local branches.
+The underlying engines that powers these are `cross::run_versions()` and `cross::run_branches()`, which allow you to run any arbitrary expression across multiple package versions or local branches.
 `cross::bench_versions()` and `cross::bench_branches()` are small wrappers around these that work seamlessly with `bench::mark()` or `bench::press()` results.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <!-- badges: end -->
 
-The goal of cross is to rerun a single function across a configuration
+The goal of cross is to run a single expression across a configuration
 of package versions or git branches. The typical use case for this is
 creating a reprex containing a before and after benchmark, where you’d
 like to run the same code on both the `main` branch and your
@@ -26,13 +26,13 @@ pak::pak("DavisVaughan/cross")
 
 ## Example
 
-`cross::bench_versions()` runs a function across various versions of the
-same package. The function itself must end with a call to either
+`cross::bench_versions()` runs an expression across various versions of
+the same package. The expression itself must end with a call to either
 `bench::mark()` or `bench::press()`. The `pkgs` can be any remote
 specification supported by `pak::pkg_install()`.
 
 ``` r
-out <- cross::bench_versions(pkgs = c("vctrs", "r-lib/vctrs"), \() {
+out <- cross::bench_versions(pkgs = c("vctrs", "r-lib/vctrs"), {
   library(vctrs)
   x <- c(1, NA, 2, 3, NA)
   bench::mark(missing = vec_detect_missing(x))
@@ -48,21 +48,21 @@ out
 #> #   time <list>, gc <list>
 ```
 
-`cross::bench_branches()` runs a function across various local branches.
-It assumes that:
+`cross::bench_branches()` runs an expression across various local
+branches. It assumes that:
 
 - `usethis::proj_get()` points to an R package using git.
 - There are no uncommitted git changes.
 
-If those are true, then it will automatically run the function against
+If those are true, then it will automatically run the expression against
 the current branch and the `main` branch, but you can change this with
 the `current` and `branches` arguments.
 
 ``` r
 # Not run here, but assuming we are in the vctrs repo this would run the
-# function against whatever branch we are on and the `main` branch
+# expression against whatever branch we are on and the `main` branch
 
-cross::bench_branches(\() {
+cross::bench_branches({
   library(vctrs)
   x <- c(1, NA, 2, 3, NA)
   bench::mark(missing = vec_detect_missing(x))
@@ -70,7 +70,7 @@ cross::bench_branches(\() {
 ```
 
 The underlying engines that powers these are `cross::run_versions()` and
-`cross::run_branches()`, which allow you to run any arbitrary function
+`cross::run_branches()`, which allow you to run any arbitrary expression
 across multiple package versions or local branches.
 `cross::bench_versions()` and `cross::bench_branches()` are small
 wrappers around these that work seamlessly with `bench::mark()` or

--- a/man/bench_branches.Rd
+++ b/man/bench_branches.Rd
@@ -2,12 +2,11 @@
 % Please edit documentation in R/bench.R
 \name{bench_branches}
 \alias{bench_branches}
-\title{Benchmark a function across different local package branches}
+\title{Benchmark an expression across different local package branches}
 \usage{
 bench_branches(
-  fn,
+  expr,
   ...,
-  args = list(),
   current = TRUE,
   branches = "main",
   libpath = .libPaths(),
@@ -16,22 +15,16 @@ bench_branches(
 )
 }
 \arguments{
-\item{fn}{\verb{[function]}
+\item{expr}{\verb{[expression]}
 
-A function to evaluate. The function is passed along to \code{\link[callr:r]{callr::r()}}, so
-it is evaluated in a fresh R session and must be self-contained.
+An expression to evaluate. The expression is passed along to \code{\link[callr:r]{callr::r()}}
+as the body of a function with zero arguments, so it is evaluated in a
+fresh R session and must be self-contained.
 
 Read the \code{func} docs of \code{\link[callr:r]{callr::r()}} for the full set of restrictions on
-\code{fn}.
-
-\code{fn} is converted to a function with \code{\link[rlang:as_function]{rlang::as_function()}}, so it can be
-a lambda function.}
+\code{expr}.}
 
 \item{...}{These dots are for future extensions and must be empty.}
-
-\item{args}{\verb{[list]}
-
-An optional list of arguments to pass to the function.}
 
 \item{current}{\verb{[TRUE / FALSE]}
 
@@ -39,8 +32,8 @@ Should the current git branch be included in the vector of \code{branches}?}
 
 \item{branches}{\verb{[character]}
 
-A character vector of git branch names to check out, install, and run \code{fn}
-against.
+A character vector of git branch names to check out, install, and run
+\code{expr} against.
 
 It is expected that your working directory is set to the git directory
 of the package you want to install different branches of. This is typically
@@ -90,7 +83,7 @@ A \verb{<bench_mark>}.
 designed to be useful when benchmarking across different local package
 branches.
 
-When using \code{bench_branches()}, each call to \code{fn} must return a \verb{<bench_mark>}
+When using \code{bench_branches()}, the \code{expr} must return a \verb{<bench_mark>}
 data frame from the bench package. This is typically generated using either a
 call to \code{\link[bench:mark]{bench::mark()}} or \code{\link[bench:press]{bench::press()}}.
 }
@@ -119,14 +112,14 @@ Defaults to \code{TRUE} if not set.
 
 \examples{
 \dontshow{if (FALSE) withAutoprint(\{ # examplesIf}
-# Similar to `bench_versions()`, but this runs the function across
+# Similar to `bench_versions()`, but this runs the expression across
 # 2 local branches.
 # To run this:
 # - The working directory is set to the RStudio project for vctrs
 # - There can't be any uncommitted git changes
 # - You are currently on a branch, say `fix/performance-bug`
 # - You'd like to run that branch against `main`
-bench_branches(~{
+bench_branches({
   library(vctrs)
   x <- c(TRUE, FALSE, NA, TRUE)
   bench::mark(vec_detect_missing(x))

--- a/man/bench_versions.Rd
+++ b/man/bench_versions.Rd
@@ -2,40 +2,33 @@
 % Please edit documentation in R/bench.R
 \name{bench_versions}
 \alias{bench_versions}
-\title{Benchmark a function across different package versions}
+\title{Benchmark an expression across different package versions}
 \usage{
 bench_versions(
-  fn,
+  expr,
   ...,
   pkgs,
-  args = list(),
   libpath = .libPaths(),
   args_pak = list(),
   args_callr = list()
 )
 }
 \arguments{
-\item{fn}{\verb{[function]}
+\item{expr}{\verb{[expression]}
 
-A function to evaluate. The function is passed along to \code{\link[callr:r]{callr::r()}}, so
-it is evaluated in a fresh R session and must be self-contained.
+An expression to evaluate. The expression is passed along to \code{\link[callr:r]{callr::r()}}
+as the body of a function with zero arguments, so it is evaluated in a
+fresh R session and must be self-contained.
 
 Read the \code{func} docs of \code{\link[callr:r]{callr::r()}} for the full set of restrictions on
-\code{fn}.
-
-\code{fn} is converted to a function with \code{\link[rlang:as_function]{rlang::as_function()}}, so it can be
-a lambda function.}
+\code{expr}.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
 \item{pkgs}{\verb{[character]}
 
 A character vector of package names or remote package specifications to
-install and run \code{fn} against. Passed along to \code{\link[pak:pkg_install]{pak::pkg_install()}}.}
-
-\item{args}{\verb{[list]}
-
-An optional list of arguments to pass to the function.}
+install and run \code{expr} against. Passed along to \code{\link[pak:pkg_install]{pak::pkg_install()}}.}
 
 \item{libpath}{\verb{[character]}
 
@@ -67,19 +60,19 @@ Can't include:
 A \verb{<bench_mark>}.
 }
 \description{
-\code{bench_versions()} allows you to run a single function, \code{fn}, multiple times
-in separate R sessions, where each R session has different versions of
+\code{bench_versions()} allows you to run a single expression, \code{expr}, multiple
+times in separate R sessions, where each R session has different versions of
 packages installed. A typical use case is running a before/after benchmark,
 comparing the CRAN version of a package with a development version of the
 same package.
 
-For example, \code{bench_versions(fn, pkgs = c("vctrs", "r-lib/vctrs#100"))} would
-run \code{fn} in 2 separate R sessions, one with CRAN vctrs installed, and one
-with the pull request installed.
+For example, \code{bench_versions(expr, pkgs = c("vctrs", "r-lib/vctrs#100"))}
+would run \code{expr} in 2 separate R sessions, one with CRAN vctrs installed, and
+one with the pull request installed.
 
-When using \code{bench_versions()}, each call to \code{fn} must return a \verb{<bench_mark>}
-data frame from the bench package. This is typically generated using either a
-call to \code{\link[bench:mark]{bench::mark()}} or \code{\link[bench:press]{bench::press()}}.
+When using \code{bench_versions()}, the \code{expr} must return a \verb{<bench_mark>} data
+frame from the bench package. This is typically generated using either a call
+to \code{\link[bench:mark]{bench::mark()}} or \code{\link[bench:press]{bench::press()}}.
 
 \code{bench_versions()} is similar to \code{\link[=run_versions]{run_versions()}}, but is specifically
 designed to be useful in conjunction with the bench package when benchmarking
@@ -111,14 +104,14 @@ Defaults to \code{TRUE} if not set.
 \examples{
 \dontshow{if (FALSE) withAutoprint(\{ # examplesIf}
 # Run a benchmark across 2 different versions of vctrs
-bench_versions(pkgs = c("vctrs", "r-lib/vctrs"), ~{
+bench_versions(pkgs = c("vctrs", "r-lib/vctrs"), {
   library(vctrs)
   x <- c(TRUE, FALSE, NA, TRUE)
   bench::mark(vec_detect_missing(x))
 })
 
 # You can also use `bench::press()` to generate a grid
-bench_versions(pkgs = c("vctrs", "r-lib/vctrs"), ~{
+bench_versions(pkgs = c("vctrs", "r-lib/vctrs"), {
   library(vctrs)
   set.seed(123)
   x <- sample(100)

--- a/man/cross-package.Rd
+++ b/man/cross-package.Rd
@@ -4,9 +4,9 @@
 \name{cross-package}
 \alias{cross}
 \alias{cross-package}
-\title{cross: Run Functions Across Package Versions}
+\title{cross: Run Expressions Across Package Versions}
 \description{
-Tooling to run a single function across multiple package versions or across multiple local branches, which is particularly useful for running before and after benchmarks.
+Tooling to run a single expression across multiple package versions or across multiple local branches, which is particularly useful for running before and after benchmarks.
 }
 \seealso{
 Useful links:

--- a/man/run_branches.Rd
+++ b/man/run_branches.Rd
@@ -2,12 +2,11 @@
 % Please edit documentation in R/run.R
 \name{run_branches}
 \alias{run_branches}
-\title{Evaluate a function across different local package branches}
+\title{Evaluate an expression across different local package branches}
 \usage{
 run_branches(
-  fn,
+  expr,
   ...,
-  args = list(),
   current = TRUE,
   branches = "main",
   libpath = .libPaths(),
@@ -16,22 +15,16 @@ run_branches(
 )
 }
 \arguments{
-\item{fn}{\verb{[function]}
+\item{expr}{\verb{[expression]}
 
-A function to evaluate. The function is passed along to \code{\link[callr:r]{callr::r()}}, so
-it is evaluated in a fresh R session and must be self-contained.
+An expression to evaluate. The expression is passed along to \code{\link[callr:r]{callr::r()}}
+as the body of a function with zero arguments, so it is evaluated in a
+fresh R session and must be self-contained.
 
 Read the \code{func} docs of \code{\link[callr:r]{callr::r()}} for the full set of restrictions on
-\code{fn}.
-
-\code{fn} is converted to a function with \code{\link[rlang:as_function]{rlang::as_function()}}, so it can be
-a lambda function.}
+\code{expr}.}
 
 \item{...}{These dots are for future extensions and must be empty.}
-
-\item{args}{\verb{[list]}
-
-An optional list of arguments to pass to the function.}
 
 \item{current}{\verb{[TRUE / FALSE]}
 
@@ -39,8 +32,8 @@ Should the current git branch be included in the vector of \code{branches}?}
 
 \item{branches}{\verb{[character]}
 
-A character vector of git branch names to check out, install, and run \code{fn}
-against.
+A character vector of git branch names to check out, install, and run
+\code{expr} against.
 
 It is expected that your working directory is set to the git directory
 of the package you want to install different branches of. This is typically
@@ -86,13 +79,13 @@ Can't include:
 A data frame with two columns:
 \itemize{
 \item \code{branch}, a character vector containing \code{branches}.
-\item \code{result}, a list column containing the result of calling \code{fn} for that
+\item \code{result}, a list column containing the result of calling \code{expr} for that
 branch of the package.
 }
 }
 \description{
 \code{run_branches()} is similar to \code{\link[=run_versions]{run_versions()}}, except it allows you to run
-\code{fn} across different local branches corresponding to the same package,
+\code{expr} across different local branches corresponding to the same package,
 rather than different CRAN or GitHub versions of that package.
 
 The default behavior runs the current branch against the \code{main} branch.
@@ -122,14 +115,14 @@ Defaults to \code{TRUE} if not set.
 
 \examples{
 \dontshow{if (FALSE) withAutoprint(\{ # examplesIf}
-# Similar to `run_versions()`, but this runs the function across
+# Similar to `run_versions()`, but this runs the expression across
 # 2 local branches.
 # To run this:
 # - The working directory is set to the RStudio project for vctrs
 # - There can't be any uncommitted git changes
 # - You are currently on a branch, say `fix/performance-bug`
 # - You'd like to run that branch against `main`
-run_branches(~{
+run_branches({
   library(vctrs)
   x <- c(TRUE, FALSE, NA, TRUE)
   bench::mark(vec_detect_missing(x))

--- a/man/run_versions.Rd
+++ b/man/run_versions.Rd
@@ -2,40 +2,33 @@
 % Please edit documentation in R/run.R
 \name{run_versions}
 \alias{run_versions}
-\title{Evaluate a function across different package versions}
+\title{Evaluate an expression across different package versions}
 \usage{
 run_versions(
-  fn,
+  expr,
   ...,
   pkgs,
-  args = list(),
   libpath = .libPaths(),
   args_pak = list(),
   args_callr = list()
 )
 }
 \arguments{
-\item{fn}{\verb{[function]}
+\item{expr}{\verb{[expression]}
 
-A function to evaluate. The function is passed along to \code{\link[callr:r]{callr::r()}}, so
-it is evaluated in a fresh R session and must be self-contained.
+An expression to evaluate. The expression is passed along to \code{\link[callr:r]{callr::r()}}
+as the body of a function with zero arguments, so it is evaluated in a
+fresh R session and must be self-contained.
 
 Read the \code{func} docs of \code{\link[callr:r]{callr::r()}} for the full set of restrictions on
-\code{fn}.
-
-\code{fn} is converted to a function with \code{\link[rlang:as_function]{rlang::as_function()}}, so it can be
-a lambda function.}
+\code{expr}.}
 
 \item{...}{These dots are for future extensions and must be empty.}
 
 \item{pkgs}{\verb{[character]}
 
 A character vector of package names or remote package specifications to
-install and run \code{fn} against. Passed along to \code{\link[pak:pkg_install]{pak::pkg_install()}}.}
-
-\item{args}{\verb{[list]}
-
-An optional list of arguments to pass to the function.}
+install and run \code{expr} against. Passed along to \code{\link[pak:pkg_install]{pak::pkg_install()}}.}
 
 \item{libpath}{\verb{[character]}
 
@@ -67,18 +60,18 @@ Can't include:
 A data frame with two columns:
 \itemize{
 \item \code{pkg}, a character vector containing \code{pkgs}.
-\item \code{result}, a list column containing the result of calling \code{fn} for that
+\item \code{result}, a list column containing the result of calling \code{expr} for that
 version of the package.
 }
 }
 \description{
-\code{run_versions()} allows you to run a single function, \code{fn}, multiple times in
-separate R sessions, where each R sessions has different versions of packages
-installed. If you're looking to run benchmarks across different versions of
-packages, you likely want \code{\link[=bench_versions]{bench_versions()}} instead.
+\code{run_versions()} allows you to run a single expression, \code{expr}, multiple
+times in separate R sessions, where each R sessions has different versions of
+packages installed. If you're looking to run benchmarks across different
+versions of packages, you likely want \code{\link[=bench_versions]{bench_versions()}} instead.
 
-For example, \code{run_versions(fn, pkgs = c("vctrs", "r-lib/vctrs#100"))} would
-run \code{fn} in 2 separate R sessions, one with CRAN vctrs installed, and one
+For example, \code{run_versions(expr, pkgs = c("vctrs", "r-lib/vctrs#100"))} would
+run \code{expr} in 2 separate R sessions, one with CRAN vctrs installed, and one
 with the pull request installed.
 }
 \details{
@@ -107,7 +100,8 @@ Defaults to \code{TRUE} if not set.
 \examples{
 \dontshow{if (FALSE) withAutoprint(\{ # examplesIf}
 # Run a benchmark across 2 different versions of vctrs
-run_versions(pkgs = c("vctrs", "r-lib/vctrs"), ~{
+# (See `bench_versions()` for an even easier way)
+run_versions(pkgs = c("vctrs", "r-lib/vctrs"), {
   library(vctrs)
   x <- c(TRUE, FALSE, NA, TRUE)
   bench::mark(vec_detect_missing(x))


### PR DESCRIPTION
From anecdotal usage, it is way more convenient to just take an expression here

i.e.

```r
cross::bench_branches(\() {
  library(lifecycle)
  
  # trigger the 8 hour warning once
  deprecate_soft("1.1.0", I("my thing"), details = "for this reason")

  bench::mark(
    deprecate_soft("1.1.0", I("my thing"), details = "for this reason"),
    iterations = 100000
  )
})
```

now no longer needs the `\()`, which feels more natural

```r
cross::bench_branches({
  library(lifecycle)
  
  # trigger the 8 hour warning once
  deprecate_soft("1.1.0", I("my thing"), details = "for this reason")

  bench::mark(
    deprecate_soft("1.1.0", I("my thing"), details = "for this reason"),
    iterations = 100000
  )
})
```

If you need to store an `expr` as a variable rather than inlining the expression, you can `!!expr` it into the call.

There is no longer any way to supply `args` to the function, but I do not actually see a real need for this.