### PR TITLE
Avoid eager splicing by using `substitute()` not `enexpr()`

### DIFF
--- a/R/bench.R
+++ b/R/bench.R
@@ -78,15 +78,16 @@ bench_versions <- function(
 
   check_dots_empty0(...)
 
-  expr <- enexpr(expr)
+  # Not `enexpr()` as that splices eagerly (#6)
+  expr <- substitute(expr)
 
-  out <- run_versions(
+  out <- inject(run_versions(
     expr = !!expr,
     pkgs = pkgs,
     libpath = libpath,
     args_pak = args_pak,
     args_callr = args_callr
-  )
+  ))
 
   pkg <- out[["pkg"]]
   bench_marks <- out[["result"]]
@@ -146,16 +147,17 @@ bench_branches <- function(
 
   check_dots_empty0(...)
 
-  expr <- enexpr(expr)
+  # Not `enexpr()` as that splices eagerly (#6)
+  expr <- substitute(expr)
 
-  out <- run_branches(
+  out <- inject(run_branches(
     expr = !!expr,
     current = current,
     branches = branches,
     libpath = libpath,
     args_pak = args_pak,
     args_callr = args_callr
-  )
+  ))
 
   branch <- out[["branch"]]
   bench_marks <- out[["result"]]

--- a/R/run.R
+++ b/R/run.R
@@ -114,7 +114,8 @@ run_versions <- function(
 
   check_dots_empty0(...)
 
-  expr <- enexpr(expr)
+  # Not `enexpr()` as that splices eagerly (#6)
+  expr <- substitute(expr)
 
   pkgs <- normalize_pkgs(pkgs)
   pkg <- pkgs[["pkg"]]
@@ -367,7 +368,8 @@ run_branches <- function(
 
   check_dots_empty0(...)
 
-  expr <- enexpr(expr)
+  # Not `enexpr()` as that splices eagerly (#6)
+  expr <- substitute(expr)
 
   check_bool(current)
   check_character(branches)


### PR DESCRIPTION
Closes #6

Basically same solution as https://github.com/r-lib/bench/pull/86

This works as expected now

``` r
cross::bench_versions(pkgs = c("rlang", "r-lib/rlang#1837"), {
  library(rlang)
  x <- as.list(1:1e6)
  bench::mark(list2(!!!x), iterations = 10)
})
#> # A tibble: 2 × 7
#>   pkg              expression       min   median `itr/sec` mem_alloc `gc/sec`
#>   <chr>            <bch:expr>  <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 rlang            list2(!!!x)    902ns   1.13µs   496738.        0B        0
#> 2 r-lib/rlang#1837 list2(!!!x)    615ns 738.07ns   880486.        0B        0
```

<sup>Created on 2025-10-09 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>